### PR TITLE
Remove upstream dependency on yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "scripts/dev.sh",
     "build": "scripts/build.sh",
     "test": "scripts/test.sh",
-    "prepublish": "yarn build"
+    "prepublish": "scripts/build.sh
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "scripts/dev.sh",
     "build": "scripts/build.sh",
     "test": "scripts/test.sh",
-    "prepublish": "scripts/build.sh
+    "prepublish": "scripts/build.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
opensea-js fails to install unless yarn is present on the system due to this prepublish step being present in a git dependecy.  It would be more compatible to rely directly on the build script, or npm which always ships with node.

The best solution though, would be to publish a real package instead of consume via git and isolate the prepublish step to just the publisher.   In the meantime, this would improve the situation a tad. 

Thanks for the cool work!