### PR TITLE
Update ERC721 Schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyvern-schemas",
-  "version": "0.10.7",
+  "version": "0.12.0",
   "files": [
     "dist"
   ],

--- a/src/schemas/ERC721/index.ts
+++ b/src/schemas/ERC721/index.ts
@@ -13,7 +13,7 @@ export interface NonFungibleContractType {
 }
 
 export const ERC721Schema: Schema<NonFungibleContractType> = {
-  version: 2,
+  version: 3,
   deploymentBlock: 0, // Not indexed (for now; need asset-specific indexing strategy)
   name: 'ERC721',
   description: 'Items conforming to the ERC721 spec, using transferFrom.',
@@ -44,7 +44,7 @@ export const ERC721Schema: Schema<NonFungibleContractType> = {
   functions: {
     transfer: asset => ({
       type: Web3.AbiType.Function,
-      name: 'transferFrom',
+      name: 'safeTransferFrom',
       payable: false,
       constant: false,
       stateMutability: StateMutability.Nonpayable,


### PR DESCRIPTION
The ERC721 schema is outdated; it specifies `transferFrom` as the preferred transfer method when we should be using `safeTransferFrom`